### PR TITLE
fix: use `path.resolve` instead of `path.join` to avoid an infinite loop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ const walkForTsConfigSync = (directory: string): string | undefined => {
     return configPath;
   }
 
-  const parentDirectory = join(directory, '../');
+  const parentDirectory = resolve(directory, '../');
 
   // If we reached the top
   if (directory === parentDirectory) {
@@ -219,7 +219,7 @@ const walkForTsConfig = async (
   }
 
   // Step up one level in the directory path.
-  const parentDirectory = join(directory, '../');
+  const parentDirectory = resolve(directory, '../');
 
   // If we reached the top
   if (directory === parentDirectory) {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail and reference any issues it addresses-->

When debugging an error with prettier and vscode, I saw that the `walkForTsConfig` got maximum callstack exceeded. When I tried a directory where there where no tsconfig in parent path I ended up in an infinite loop as the `path.join` does not check if the directory actually exists, it just joins the paths. This PR will use resolve instead of join in order to resolve the infinite loop issue.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project and `	` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .
