### PR TITLE
fix: update package.json to include the repository key

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "walking",
     "path"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ifiokjr/tsconfig-resolver.git"
+  },
   "funding": "https://github.com/sponsors/ifiokjr",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
* tsconfig-resolver

## Description

<!-- Describe your changes in detail and reference any issues it addresses-->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project and `yarn lint --fix` runs successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .
